### PR TITLE
fix: resolve issue where build quality could be incorrect

### DIFF
--- a/src/PulseBridge.Condo.Build/Scripts/condo.sh
+++ b/src/PulseBridge.Condo.Build/Scripts/condo.sh
@@ -160,6 +160,17 @@ while [[ $# > 0 ]]; do
             CLR_CLEAR=
             MSBUILD_DISABLE_COLOR="DisableConsoleColor"
             ;;
+        --bootstrap)
+            BOOTSTRAP=1
+            ;;
+        --username)
+            BOOTSTRAP_USERNAME=$2
+            shift
+            ;;
+        --password)
+            BOOTSTRAP_PASSWORD=$2
+            shift
+            ;;
         *)
             break
             ;;
@@ -224,10 +235,16 @@ cat > $MSBUILD_RSP <<END_MSBUILD_RSP
 "$CONDO_PROJ"
 -p:CondoTargetsPath="$CONDO_TARGETS/"
 -p:CondoTasksPath="$CONDO_PUBLISH/"
+-p:PackageFeedUsername=$BOOTSTRAP_USERNAME
+-p:PackageFeedPassword=$BOOTSTRAP_PASSWORD
 -fl
 -flp:LogFile="$MSBUILD_LOG";Encoding=UTF-8;Verbosity=$CONDO_VERBOSITY
 -clp:$MSBUILD_DISABLE_COLOR;Verbosity=$CONDO_VERBOSITY
 END_MSBUILD_RSP
+
+if [ "$BOOTSTRAP" = "1" ]; then
+safe-join $'\n' "-t:Bootstrap" >> $MSBUILD_RSP
+fi
 
 # write out msbuild arguments to the rsp
 safe-join $'\n' "$@" >> $MSBUILD_RSP

--- a/src/PulseBridge.Condo.Build/Tasks/GetRepositoryInfo.cs
+++ b/src/PulseBridge.Condo.Build/Tasks/GetRepositoryInfo.cs
@@ -74,12 +74,19 @@ namespace PulseBridge.Condo.Build.Tasks
             var result = this.TryCommandLine(root) || this.TryFileSystem(root);
 
             // determine if we were successful and the repository url ends with a ".git" extension
-            if (!string.IsNullOrEmpty(this.RepositoryUri) && this.RepositoryUri.EndsWith(".git"))
+            if (this.RepositoryUri != null && this.RepositoryUri.EndsWith(".git"))
             {
                 // strip the '.git' from the uri
                 // tricky: this is done to support browsing to the repository from
                 // a browser rather than just cloning directly for github
                 this.RepositoryUri.Substring(0, this.RepositoryUri.Length - 4);
+            }
+
+            // determine if the branch is set and starts with /refs/heads
+            if (this.Branch != null && this.Branch.ToLower().StartsWith("refs/heads/"))
+            {
+                // remove the /refs/heads reference from the branch name
+                this.Branch = this.Branch.Substring(11);
             }
 
             // return the result
@@ -221,9 +228,7 @@ namespace PulseBridge.Condo.Build.Tasks
                 if (string.IsNullOrEmpty(this.Branch))
                 {
                     // get the branch
-                    this.Branch = branch.StartsWith("refs/heads/")
-                        ? branch.Substring(11)
-                        : branch;
+                    this.Branch = branch;
                 }
 
                 // get the branch node marker path

--- a/template/condo.sh
+++ b/template/condo.sh
@@ -66,6 +66,9 @@ while [[ $# > 0 ]]; do
             CLR_CLEAR=
             break
             ;;
+        --username|--password)
+            shift
+            ;;
         --)
             shift
             break

--- a/test/PulseBridge.Condo.Build.Test/PulseBridge.Condo.Build.Test.nuget.props
+++ b/test/PulseBridge.Condo.Build.Test/PulseBridge.Condo.Build.Test.nuget.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
+    <NuGetPackageRoot>/Users/dmccaffery/.nuget/packages/</NuGetPackageRoot>
+  </PropertyGroup>
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)microsoft.diasymreader.native/1.4.0-rc2/build/Microsoft.DiaSymReader.Native.props" Condition="Exists('$(NuGetPackageRoot)microsoft.diasymreader.native/1.4.0-rc2/build/Microsoft.DiaSymReader.Native.props')" />
+  </ImportGroup>
+</Project>

--- a/test/PulseBridge.Condo.Build.Test/Tasks/GetRepositoryInfoTest.cs
+++ b/test/PulseBridge.Condo.Build.Test/Tasks/GetRepositoryInfoTest.cs
@@ -95,6 +95,7 @@ namespace PulseBridge.Condo.Build.Tasks
             }
         }
 
+        [Fact]
         [Priority(2)]
         [Purpose(PurposeType.Integration)]
         public void Execute_WhenRepositoryRootValid_Succeeds()
@@ -115,6 +116,42 @@ namespace PulseBridge.Condo.Build.Tasks
                 {
                     RepositoryRoot = root,
                     BuildEngine = engine
+                };
+
+                // act
+                var result = actual.Execute();
+
+                // assert
+                Assert.True(result);
+                Assert.Equal(expected.RepositoryRoot, actual.RepositoryRoot);
+                Assert.Equal(expected.Branch, actual.Branch);
+                Assert.NotNull(actual.CommitId);
+            }
+        }
+
+        [Fact]
+        [Priority(2)]
+        [Purpose(PurposeType.Integration)]
+        public void Execute_WhenBranchRefSet_UsesAbbreviatedBranch()
+        {
+            using (var repo = new GitRepository().Initialize().Commit("initial"))
+            {
+                // arrange
+                var root = repo.RepositoryPath;
+                var engine = MSBuildMocks.CreateEngine();
+                var branch = "refs/heads/master";
+
+                var expected = new
+                {
+                    RepositoryRoot = root,
+                    Branch = "master"
+                };
+
+                var actual = new GetRepositoryInfo
+                {
+                    RepositoryRoot = root,
+                    BuildEngine = engine,
+                    Branch = branch
                 };
 
                 // act
@@ -338,7 +375,7 @@ namespace PulseBridge.Condo.Build.Tasks
                 var expected = new
                 {
                     RepositoryRoot = root,
-                    Branch= "master"
+                    Branch= "refs/heads/master"
                 };
 
                 var actual = new GetRepositoryInfo

--- a/test/PulseBridge.Condo.E2E.Test/InitializeTest.cs
+++ b/test/PulseBridge.Condo.E2E.Test/InitializeTest.cs
@@ -12,7 +12,6 @@ namespace PulseBridge.Condo
 
     using PulseBridge.Condo.IO;
 
-    [Agent(AgentType.Local)]
     [Purpose(PurposeType.EndToEnd)]
     public class InitializeTest
     {

--- a/test/PulseBridge.Condo.E2E.Test/PulseBridge.Condo.E2E.Test.nuget.props
+++ b/test/PulseBridge.Condo.E2E.Test/PulseBridge.Condo.E2E.Test.nuget.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
+    <NuGetPackageRoot>/Users/dmccaffery/.nuget/packages/</NuGetPackageRoot>
+  </PropertyGroup>
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)microsoft.diasymreader.native/1.4.0-rc2/build/Microsoft.DiaSymReader.Native.props" Condition="Exists('$(NuGetPackageRoot)microsoft.diasymreader.native/1.4.0-rc2/build/Microsoft.DiaSymReader.Native.props')" />
+  </ImportGroup>
+</Project>

--- a/test/PulseBridge.Condo.Testing.Test/PulseBridge.Condo.Testing.Test.nuget.props
+++ b/test/PulseBridge.Condo.Testing.Test/PulseBridge.Condo.Testing.Test.nuget.props
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="'$(NuGetPackageRoot)' == ''">
+    <NuGetPackageRoot>/Users/dmccaffery/.nuget/packages/</NuGetPackageRoot>
+  </PropertyGroup>
+  <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' != 'true' ">
+    <Import Project="$(NuGetPackageRoot)microsoft.diasymreader.native/1.4.0-rc2/build/Microsoft.DiaSymReader.Native.props" Condition="Exists('$(NuGetPackageRoot)microsoft.diasymreader.native/1.4.0-rc2/build/Microsoft.DiaSymReader.Native.props')" />
+  </ImportGroup>
+</Project>


### PR DESCRIPTION
When a CI server set the Build variable to a non-abbreviated form (such as refs/heads/develop), the build quality could be mis-identified as 'alpha'. We verify the start of a string as a match to a well-known branch, which required the abbreviated form previously. This has been resolved whereby the branch name is always abbreviated.