### PR TITLE
fix(release): set author name/email

### DIFF
--- a/src/PulseBridge.Condo/Targets/Versioning/Conventional.targets
+++ b/src/PulseBridge.Condo/Targets/Versioning/Conventional.targets
@@ -84,10 +84,22 @@
   </Target>
 
   <Target Name="CreateRelease" Condition=" $(CI) AND $(HasGit) AND !$(IsPullRequest) ">
+    <PropertyGroup>
+      <AuthorName Condition=" '$(AuthorName)' == '' ">$(GIT_AUTHOR_NAME)</AuthorName>
+      <AuthorName Condition=" '$(AuthorName)' == '' ">$(Company)</AuthorName>
+      <AuthorName Condition=" '$(AuthorName)' == '' ">$(Authors)</AuthorName>
+      <AuthorName Condition=" '$(AuthorName)' == '' ">condo</AuthorName>
+
+      <AuthorEmail Condition=" '$(AuthorEmail)' == '' ">$(GIT_AUTHOR_EMAIL)</AuthorEmail>
+      <AuthorEmail Condition=" '$(AuthorEmail)' == '' ">condo@pulsebridge</AuthorEmail>
+    </PropertyGroup>
+
     <CreateRelease
       RepositoryRoot="$(RepositoryRoot)"
       Version="$(VersionTag)$(InformationalVersion)"
-      ReleaseMessage="$(ReleaseMessage)" />
+      ReleaseMessage="$(ReleaseMessage)"
+      AuthorName="$(AuthorName)"
+      AuthorEmail="$(AuthorEmail)" />
   </Target>
 
   <PropertyGroup>

--- a/src/PulseBridge.Condo/Tasks/CreateRelease.cs
+++ b/src/PulseBridge.Condo/Tasks/CreateRelease.cs
@@ -35,6 +35,16 @@ namespace PulseBridge.Condo.Tasks
         /// Gets or sets the remote that should be used to push the tag.
         /// </summary>
         public string Remote { get; set; } = "origin";
+
+        /// <summary>
+        /// Gets or sets the author name used for git commits.
+        /// </summary>
+        public string AuthorName { get; set; } = "condo";
+
+        /// <summary>
+        /// Gets or sets the author email used for git commits.
+        /// </summary>
+        public string AuthorEmail { get; set; } = "condo@pulsebridge";
         #endregion
 
         #region Methods
@@ -73,6 +83,10 @@ namespace PulseBridge.Condo.Tasks
             {
                 // load the repository
                 var repository = factory.Load(root);
+
+                // set the username and email
+                repository.Username = this.AuthorName;
+                repository.Email = this.AuthorEmail;
 
                 // create a release message
                 var message = this.ReleaseMessage + this.Version;


### PR DESCRIPTION
* resolve an issue where git commit containing changelog does not succeed if git author name and email is not set by the build agent
* use git environment variables for git author name and email
* fallback to reasonable defaults for build system