### PR TITLE
fix(release): set author name/email

### DIFF
--- a/src/PulseBridge.Condo/Targets/Versioning/Conventional.targets
+++ b/src/PulseBridge.Condo/Targets/Versioning/Conventional.targets
@@ -84,10 +84,22 @@
   </Target>
 
   <Target Name="CreateRelease" Condition=" $(CI) AND $(HasGit) AND !$(IsPullRequest) ">
+    <PropertyGroup>
+      <AuthorName Condition=" '$(AuthorName)' == '' ">$(GIT_AUTHOR_NAME)</AuthorName>
+      <AuthorName Condition=" '$(AuthorName)' == '' ">$(Company)</AuthorName>
+      <AuthorName Condition=" '$(AuthorName)' == '' ">$(Authors)</AuthorName>
+      <AuthorName Condition=" '$(AuthorName)' == '' ">condo</AuthorName>
+
+      <AuthorEmail Condition=" '$(AuthorEmail)' == '' ">$(GIT_AUTHOR_EMAIL)</AuthorEmail>
+      <AuthorEmail Condition=" '$(AuthorEmail)' == '' ">condo@pulsebridge</AuthorEmail>
+    </PropertyGroup>
+
     <CreateRelease
       RepositoryRoot="$(RepositoryRoot)"
       Version="$(VersionTag)$(InformationalVersion)"
-      ReleaseMessage="$(ReleaseMessage)" />
+      ReleaseMessage="$(ReleaseMessage)"
+      AuthorName="$(AuthorName)"
+      AuthorEmail="$(AuthorEmail)" />
   </Target>
 
   <PropertyGroup>

--- a/src/PulseBridge.Condo/Tasks/CreateRelease.cs
+++ b/src/PulseBridge.Condo/Tasks/CreateRelease.cs
@@ -35,6 +35,16 @@ namespace PulseBridge.Condo.Tasks
         /// Gets or sets the remote that should be used to push the tag.
         /// </summary>
         public string Remote { get; set; } = "origin";
+
+        /// <summary>
+        /// Gets or sets the author name used for git commits.
+        /// </summary>
+        public string AuthorName { get; set; } = "condo";
+
+        /// <summary>
+        /// Gets or sets the author email used for git commits.
+        /// </summary>
+        public string AuthorEmail { get; set; } = "condo@pulsebridge";
         #endregion
 
         #region Methods
@@ -73,6 +83,10 @@ namespace PulseBridge.Condo.Tasks
             {
                 // load the repository
                 var repository = factory.Load(root);
+
+                // set the username and email
+                repository.Username = this.AuthorName;
+                repository.Email = this.AuthorEmail;
 
                 // create a release message
                 var message = this.ReleaseMessage + this.Version;

--- a/test/PulseBridge.Condo.E2E.Test/IO/GitLogTest.cs
+++ b/test/PulseBridge.Condo.E2E.Test/IO/GitLogTest.cs
@@ -19,8 +19,15 @@ namespace PulseBridge.Condo.IO
         [Theory]
         public void GitLog_WhenSimple_Succeeds(CommitMessage expected)
         {
-            using (var repo = this.repository.Initialize().Commit(expected.Raw))
+            using (var repo = this.repository.Initialize())
             {
+                // set the username and email
+                repo.Username = "condo";
+                repo.Email = "condo@pulsebridge";
+
+                // commit
+                repo.Commit(expected.Raw);
+
                 // arrange
                 foreach (var tag in expected.Tags)
                 {

--- a/test/PulseBridge.Condo.E2E.Test/InitializeTest.cs
+++ b/test/PulseBridge.Condo.E2E.Test/InitializeTest.cs
@@ -29,8 +29,15 @@ namespace PulseBridge.Condo
         [Platform(PlatformType.MacOS)]
         public async Task Initialize_OnTfsMacAgent_Succeeds()
         {
-            using (var repo = repository.Initialize().Commit("initial"))
+            using (var repo = repository.Initialize())
             {
+                // set the username and email
+                repo.Username = "condo";
+                repo.Email = "condo@pulsebridge";
+
+                // commit
+                repo.Commit("initial");
+
                 // arrange
                 var definitionId = Guid.NewGuid().ToString();
                 var ci = "true";
@@ -123,8 +130,15 @@ namespace PulseBridge.Condo
         [Platform(PlatformType.Windows)]
         public async Task Initialize_OnTfsWindowsAgent_Succeeds()
         {
-            using (var repo = repository.Initialize().Commit("initial"))
+            using (var repo = repository.Initialize())
             {
+                // set the username and email
+                repo.Username = "condo";
+                repo.Email = "condo@pulsebridge";
+
+                // commit
+                repo.Commit("initial");
+
                 // arrange
                 var definitionId = Guid.NewGuid().ToString();
                 var ci = "true";

--- a/test/PulseBridge.Condo.Test/Tasks/GetCommitInfoTest.cs
+++ b/test/PulseBridge.Condo.Test/Tasks/GetCommitInfoTest.cs
@@ -106,6 +106,10 @@ namespace PulseBridge.Condo.Tasks
         {
             using (var repo = repository.Initialize())
             {
+                // set the username and email
+                repo.Username = "condo";
+                repo.Email = "condo@pulsebridge";
+
                 // arrange
                 var root = repo.RepositoryPath;
                 var expected = new

--- a/test/PulseBridge.Condo.Test/Tasks/GetRepositoryInfoTest.cs
+++ b/test/PulseBridge.Condo.Test/Tasks/GetRepositoryInfoTest.cs
@@ -102,8 +102,15 @@ namespace PulseBridge.Condo.Tasks
         [Purpose(PurposeType.Integration)]
         public void Execute_WhenRepositoryRootValid_Succeeds()
         {
-            using (var repo = repository.Initialize().Commit("initial"))
+            using (var repo = repository.Initialize())
             {
+                // set the username and email
+                repo.Username = "condo";
+                repo.Email = "condo@pulsebridge";
+
+                // commit
+                repo.Commit("initial");
+
                 // arrange
                 var root = repo.RepositoryPath;
                 var engine = MSBuildMocks.CreateEngine();
@@ -136,8 +143,15 @@ namespace PulseBridge.Condo.Tasks
         [Purpose(PurposeType.Integration)]
         public void Execute_WhenBranchRefSet_UsesAbbreviatedBranch()
         {
-            using (var repo = repository.Initialize().Commit("initial"))
+            using (var repo = repository.Initialize())
             {
+                // set the username and email
+                repo.Username = "condo";
+                repo.Email = "condo@pulsebridge";
+
+                // commit
+                repo.Commit("initial");
+
                 // arrange
                 var root = repo.RepositoryPath;
                 var engine = MSBuildMocks.CreateEngine();
@@ -254,8 +268,15 @@ namespace PulseBridge.Condo.Tasks
         [Purpose(PurposeType.Unit)]
         public void TryCommandLine_WhenRepositoryRootValid_Succeeds()
         {
-            using (var repo = repository.Initialize().Commit("initial"))
+            using (var repo = repository.Initialize())
             {
+                // set the username and email
+                repo.Username = "condo";
+                repo.Email = "condo@pulsebridge";
+
+                // commit
+                repo.Commit("initial");
+
                 // arrange
                 var root = repo.RepositoryPath;
                 var engine = MSBuildMocks.CreateEngine();

--- a/test/PulseBridge.Condo.Test/Tasks/SetGitTagTest.cs
+++ b/test/PulseBridge.Condo.Test/Tasks/SetGitTagTest.cs
@@ -146,8 +146,15 @@ namespace PulseBridge.Condo.Tasks
         {
             using (var bare = repository.Bare())
             {
-                using (var repo = repository.Clone(bare.RepositoryPath).Commit("initial"))
+                using (var repo = repository.Clone(bare.RepositoryPath))
                 {
+                    // set the username and email
+                    repo.Username = "condo";
+                    repo.Email = "condo@pulsebridge";
+
+                    // commit
+                    repo.Commit("initial");
+
                     // arrange
                     var root = repo.RepositoryPath;
                     var tag = "tag-1-2-3";


### PR DESCRIPTION
* resolve an issue where git commit containing changelog does not succeed if git author name and email is not set by the build agent
* use git environment variables for git author name and email
* fallback to reasonable defaults for build system